### PR TITLE
writer: transpose BYTE_STREAM_SPLIT once per page, at finalize

### DIFF
--- a/src/writer/page_writer.c
+++ b/src/writer/page_writer.c
@@ -55,25 +55,10 @@ extern int carquet_zstd_compress(const uint8_t* src, size_t src_size,
                                   size_t* dst_size, int level);
 extern size_t carquet_zstd_compress_bound(size_t src_size);
 
-extern carquet_status_t carquet_byte_stream_split_encode_float(
-    const float* values,
-    int64_t count,
-    uint8_t* output,
-    size_t output_capacity,
-    size_t* bytes_written);
-extern carquet_status_t carquet_byte_stream_split_encode_double(
-    const double* values,
-    int64_t count,
-    uint8_t* output,
-    size_t output_capacity,
-    size_t* bytes_written);
-extern carquet_status_t carquet_byte_stream_split_encode(
-    const uint8_t* values,
-    int64_t count,
-    int32_t type_length,
-    uint8_t* output,
-    size_t output_capacity,
-    size_t* bytes_written);
+/* The incremental BYTE_STREAM_SPLIT encoders in encoding/byte_stream_split.c
+ * are no longer called from here: the transposition is applied to the finished
+ * page by apply_byte_stream_split() below. */
+
 extern carquet_status_t carquet_delta_encode_int32(
     const int32_t* values, int32_t num_values,
     uint8_t* data, size_t data_capacity, size_t* bytes_written);
@@ -143,6 +128,7 @@ typedef struct carquet_page_writer {
     int64_t* def_level_hist;
 
     bool data_page_v2;       /* Emit DATA_PAGE_V2 instead of DATA_PAGE */
+    bool bss_applied;        /* Page already transposed by finalize */
 
     int32_t compression_level;   /* 0 = use codec default */
 
@@ -316,6 +302,7 @@ void carquet_page_writer_destroy(carquet_page_writer_t* writer) {
 
 void carquet_page_writer_reset(carquet_page_writer_t* writer) {
     carquet_buffer_clear(&writer->values_buffer);
+    writer->bss_applied = false;
     carquet_buffer_clear(&writer->def_levels_buffer);
     carquet_buffer_clear(&writer->rep_levels_buffer);
     carquet_buffer_clear(&writer->staging_buffer);
@@ -916,23 +903,12 @@ static carquet_status_t encode_float_values(
         return CARQUET_OK;
     }
 
-    if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
-        size_t bytes_needed = (size_t)count * sizeof(float);
-        size_t offset = writer->values_buffer.size;
-        uint8_t* dest = carquet_buffer_advance(&writer->values_buffer, bytes_needed);
-        size_t bytes_written = 0;
-        if (!dest) {
-            return CARQUET_ERROR_OUT_OF_MEMORY;
-        }
-        carquet_status_t status = carquet_byte_stream_split_encode_float(
-            values, count, dest, bytes_needed, &bytes_written);
-        if (status != CARQUET_OK || bytes_written != bytes_needed) {
-            writer->values_buffer.size = offset;
-            return status != CARQUET_OK ? status : CARQUET_ERROR_ENCODE;
-        }
-        return CARQUET_OK;
-    }
-
+    /* BYTE_STREAM_SPLIT transposes a whole page into byte planes, so it
+     * cannot be applied incrementally. Splitting each call's subrange and
+     * appending produced independently transposed regions that the decoder
+     * de-splits as a single stride, corrupting every value in any page built
+     * from more than one call. Raw values accumulate here and
+     * apply_byte_stream_split() transposes the page once, at finalize. */
     return carquet_encode_plain_float(values, count, &writer->values_buffer);
 }
 
@@ -945,23 +921,7 @@ static carquet_status_t encode_double_values(
         return CARQUET_OK;
     }
 
-    if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
-        size_t bytes_needed = (size_t)count * sizeof(double);
-        size_t offset = writer->values_buffer.size;
-        uint8_t* dest = carquet_buffer_advance(&writer->values_buffer, bytes_needed);
-        size_t bytes_written = 0;
-        if (!dest) {
-            return CARQUET_ERROR_OUT_OF_MEMORY;
-        }
-        carquet_status_t status = carquet_byte_stream_split_encode_double(
-            values, count, dest, bytes_needed, &bytes_written);
-        if (status != CARQUET_OK || bytes_written != bytes_needed) {
-            writer->values_buffer.size = offset;
-            return status != CARQUET_OK ? status : CARQUET_ERROR_ENCODE;
-        }
-        return CARQUET_OK;
-    }
-
+    /* See encode_float_values(). */
     return carquet_encode_plain_double(values, count, &writer->values_buffer);
 }
 
@@ -980,18 +940,9 @@ static carquet_status_t encode_int32_values(
     size_t offset = writer->values_buffer.size;
 
     if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
-        size_t need = (size_t)count * sizeof(int32_t);
-        uint8_t* dest = carquet_buffer_advance(&writer->values_buffer, need);
-        if (!dest) return CARQUET_ERROR_OUT_OF_MEMORY;
-        size_t written = 0;
-        carquet_status_t s = carquet_byte_stream_split_encode(
-            (const uint8_t*)values, count, (int32_t)sizeof(int32_t),
-            dest, need, &written);
-        if (s != CARQUET_OK || written != need) {
-            writer->values_buffer.size = offset;
-            return s != CARQUET_OK ? s : CARQUET_ERROR_ENCODE;
-        }
-        return CARQUET_OK;
+        /* Accumulate raw values; apply_byte_stream_split() transposes the page
+         * once, at finalize. See encode_float_values(). */
+        return carquet_encode_plain_int32(values, count, &writer->values_buffer);
     }
 
     if (writer->encoding == CARQUET_ENCODING_DELTA_BINARY_PACKED) {
@@ -1023,18 +974,9 @@ static carquet_status_t encode_int64_values(
     size_t offset = writer->values_buffer.size;
 
     if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
-        size_t need = (size_t)count * sizeof(int64_t);
-        uint8_t* dest = carquet_buffer_advance(&writer->values_buffer, need);
-        if (!dest) return CARQUET_ERROR_OUT_OF_MEMORY;
-        size_t written = 0;
-        carquet_status_t s = carquet_byte_stream_split_encode(
-            (const uint8_t*)values, count, (int32_t)sizeof(int64_t),
-            dest, need, &written);
-        if (s != CARQUET_OK || written != need) {
-            writer->values_buffer.size = offset;
-            return s != CARQUET_OK ? s : CARQUET_ERROR_ENCODE;
-        }
-        return CARQUET_OK;
+        /* Accumulate raw values; apply_byte_stream_split() transposes the page
+         * once, at finalize. See encode_float_values(). */
+        return carquet_encode_plain_int64(values, count, &writer->values_buffer);
     }
 
     if (writer->encoding == CARQUET_ENCODING_DELTA_BINARY_PACKED) {
@@ -1288,21 +1230,11 @@ carquet_status_t carquet_page_writer_add_values(
         case CARQUET_PHYSICAL_FIXED_LEN_BYTE_ARRAY: {
             const uint8_t* fixed = (const uint8_t*)values;
             if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
-                size_t need = (size_t)num_non_null * (size_t)writer->type_length;
-                size_t off = writer->values_buffer.size;
-                uint8_t* dest = carquet_buffer_advance(&writer->values_buffer, need);
-                if (!dest) {
-                    status = CARQUET_ERROR_OUT_OF_MEMORY;
-                } else {
-                    size_t written = 0;
-                    status = carquet_byte_stream_split_encode(
-                        fixed, num_non_null, writer->type_length,
-                        dest, need, &written);
-                    if (status != CARQUET_OK || written != need) {
-                        writer->values_buffer.size = off;
-                        if (status == CARQUET_OK) status = CARQUET_ERROR_ENCODE;
-                    }
-                }
+                /* Accumulate raw values; apply_byte_stream_split() transposes
+                 * the page once, at finalize. See encode_float_values(). */
+                status = carquet_encode_plain_fixed_byte_array(
+                    fixed, num_non_null, writer->type_length,
+                    &writer->values_buffer);
             } else if (writer->encoding == CARQUET_ENCODING_DELTA_BYTE_ARRAY) {
                 /* Spec allows DELTA_BYTE_ARRAY for FLBA: present each
                  * fixed-width value as a byte array of length type_length. */
@@ -1828,6 +1760,57 @@ static carquet_status_t finalize_v2_to_buffer(
  * ============================================================================
  */
 
+/* Transpose the accumulated raw values into BYTE_STREAM_SPLIT byte
+ * planes, once, for the whole page. Byte-wise so it does not depend on the
+ * value buffer being aligned for float or double access. Idempotent within a
+ * page: finalize may be called more than once before the writer is reset. */
+static carquet_status_t apply_byte_stream_split(carquet_page_writer_t* writer) {
+    if (writer->encoding != CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
+        return CARQUET_OK;
+    }
+    if (writer->bss_applied || writer->values_buffer.size == 0) {
+        return CARQUET_OK;
+    }
+
+    size_t width;
+    switch (writer->type) {
+        case CARQUET_PHYSICAL_FLOAT:  width = sizeof(float);   break;
+        case CARQUET_PHYSICAL_DOUBLE: width = sizeof(double);  break;
+        case CARQUET_PHYSICAL_INT32:  width = sizeof(int32_t); break;
+        case CARQUET_PHYSICAL_INT64:  width = sizeof(int64_t); break;
+        case CARQUET_PHYSICAL_FIXED_LEN_BYTE_ARRAY:
+            if (writer->type_length <= 0) {
+                return CARQUET_ERROR_ENCODE;
+            }
+            width = (size_t)writer->type_length;
+            break;
+        default:
+            /* BYTE_STREAM_SPLIT is not defined for the remaining physical
+             * types, and the encoding selector never chooses it for them. */
+            return CARQUET_ERROR_ENCODE;
+    }
+    size_t size = writer->values_buffer.size;
+    if (size % width != 0) {
+        return CARQUET_ERROR_ENCODE;
+    }
+    size_t count = size / width;
+
+    uint8_t* planes = (uint8_t*)carquet_mem_malloc(size);
+    if (!planes) {
+        return CARQUET_ERROR_OUT_OF_MEMORY;
+    }
+    const uint8_t* src = writer->values_buffer.data;
+    for (size_t i = 0; i < count; i++) {
+        for (size_t b = 0; b < width; b++) {
+            planes[b * count + i] = src[i * width + b];
+        }
+    }
+    memcpy(writer->values_buffer.data, planes, size);
+    carquet_mem_free(planes);
+    writer->bss_applied = true;
+    return CARQUET_OK;
+}
+
 carquet_status_t carquet_page_writer_finalize(
     carquet_page_writer_t* writer,
     const uint8_t** page_data,
@@ -1859,6 +1842,11 @@ carquet_status_t carquet_page_writer_finalize_to_buffer(
 
     if (!writer || !output_buffer || !page_size) {
         return CARQUET_ERROR_INVALID_ARGUMENT;
+    }
+
+    carquet_status_t split_status = apply_byte_stream_split(writer);
+    if (split_status != CARQUET_OK) {
+        return split_status;
     }
 
     if (writer->data_page_v2) {

--- a/tests/test_encoding_roundtrip.c
+++ b/tests/test_encoding_roundtrip.c
@@ -167,6 +167,61 @@ static int test_bss(const char* name, const char* base,
     return 0;
 }
 
+/* BYTE_STREAM_SPLIT transposes a whole page into byte planes, so it is only
+ * correct when applied to the finished page. Writing the same page in several
+ * carquet_writer_write_batch() calls must therefore produce byte-identical
+ * output to writing it in one. The chunk sizes below are deliberately not
+ * multiples of any value width, so a per-call split leaves independently
+ * transposed regions that the reader de-splits as a single stride. */
+static int test_bss_chunked(const char* name, const char* base,
+                            carquet_physical_type_t phys, int32_t tl, size_t esz) {
+    static const int64_t chunks[] = { 7, 1, 1992, 2000 };
+    char path[512]; carquet_test_temp_path(path, sizeof(path), base);
+    static uint8_t in[N * 8], out[N * 8];
+    size_t bytes = (size_t)N * esz;
+    for (size_t i = 0; i < bytes; i++) in[i] = (uint8_t)((i * 131 + 7) & 0xFF);
+
+    carquet_error_t err = CARQUET_ERROR_INIT;
+    carquet_schema_t* s = carquet_schema_create(&err);
+    if (!s) TEST_FAIL(name, "schema create failed");
+    if (carquet_schema_add_column(s, "c", phys, NULL,
+                                  CARQUET_REPETITION_REQUIRED, tl, 0) != CARQUET_OK) {
+        carquet_schema_free(s); TEST_FAIL(name, "add column failed");
+    }
+    carquet_writer_options_t wo;
+    carquet_writer_options_init(&wo);
+    carquet_writer_t* w = carquet_writer_create(path, s, &wo, &err);
+    if (!w) { carquet_schema_free(s); TEST_FAIL(name, "writer create failed"); }
+    if (carquet_writer_set_column_encoding(
+            w, 0, CARQUET_ENCODING_BYTE_STREAM_SPLIT) != CARQUET_OK) {
+        carquet_writer_close(w); carquet_schema_free(s);
+        TEST_FAIL(name, "set encoding failed");
+    }
+    int64_t done = 0;
+    for (size_t k = 0; k < sizeof(chunks) / sizeof(chunks[0]); k++) {
+        if (carquet_writer_write_batch(w, 0, in + (size_t)done * esz,
+                                       chunks[k], NULL, NULL) != CARQUET_OK) {
+            carquet_writer_close(w); carquet_schema_free(s);
+            TEST_FAIL(name, "write batch failed");
+        }
+        done += chunks[k];
+    }
+    if (carquet_writer_close(w) != CARQUET_OK) {
+        carquet_schema_free(s); TEST_FAIL(name, "writer close failed");
+    }
+    carquet_schema_free(s);
+
+    carquet_reader_t* r = carquet_reader_open(path, NULL, &err);
+    if (!r) TEST_FAIL(name, "open failed");
+    carquet_column_reader_t* c = carquet_reader_get_column(r, 0, 0, &err);
+    int64_t n = c ? carquet_column_read_batch(c, out, N, NULL, NULL) : -1;
+    int ok = (done == N) && (n == N) && (memcmp(in, out, bytes) == 0);
+    carquet_column_reader_free(c); carquet_reader_close(r); carquet_test_cleanup(path);
+    if (!ok) TEST_FAIL(name, "value mismatch");
+    TEST_PASS(name);
+    return 0;
+}
+
 static int test_delta_byte_array_nullable(void) {
     /* Nullable DELTA_BYTE_ARRAY: exercises the reconstruction scratch together
      * with definition levels (packed non-null value stream). */
@@ -217,6 +272,11 @@ int main(void) {
     failures += test_bss("bss_int32",  "bss_i32", CARQUET_PHYSICAL_INT32, 0, 4);
     failures += test_bss("bss_int64",  "bss_i64", CARQUET_PHYSICAL_INT64, 0, 8);
     failures += test_bss("bss_flba",   "bss_flba", CARQUET_PHYSICAL_FIXED_LEN_BYTE_ARRAY, 6, 6);
+    failures += test_bss_chunked("bss_float_chunked",  "bssc_f32", CARQUET_PHYSICAL_FLOAT, 0, 4);
+    failures += test_bss_chunked("bss_double_chunked", "bssc_f64", CARQUET_PHYSICAL_DOUBLE, 0, 8);
+    failures += test_bss_chunked("bss_int32_chunked",  "bssc_i32", CARQUET_PHYSICAL_INT32, 0, 4);
+    failures += test_bss_chunked("bss_int64_chunked",  "bssc_i64", CARQUET_PHYSICAL_INT64, 0, 8);
+    failures += test_bss_chunked("bss_flba_chunked",   "bssc_flba", CARQUET_PHYSICAL_FIXED_LEN_BYTE_ARRAY, 6, 6);
     if (failures) { printf("\n%d test(s) FAILED\n", failures); return 1; }
     printf("\nAll encoding roundtrip tests passed\n");
     return 0;

--- a/tests/test_writer_extensions.c
+++ b/tests/test_writer_extensions.c
@@ -1247,9 +1247,105 @@ static int test_file_format_version(void) {
     return 0;
 }
 
+/* ---- BYTE_STREAM_SPLIT: exact on-disk bytes ---- */
+/* A round-trip through carquet's own decoder cannot tell a correct page from a
+ * self-consistently wrong one, so this asserts the literal page payload.
+ *
+ * Four INT32 values, chosen so their little-endian bytes are readable by eye:
+ *
+ *   0x04030201 -> 01 02 03 04
+ *   0x08070605 -> 05 06 07 08
+ *   0x0C0B0A09 -> 09 0A 0B 0C
+ *   0x100F0E0D -> 0D 0E 0F 10
+ *
+ * BYTE_STREAM_SPLIT with element width 4 and 4 values emits four planes of four
+ * bytes: plane b holds byte b of every value, in order. So the page payload
+ * must be exactly
+ *
+ *   01 05 09 0D | 02 06 0A 0E | 03 07 0B 0F | 04 08 0C 10
+ *
+ * They are written as 1 + 3 values, so a per-call split would instead produce
+ * value 0 transposed alone followed by values 1..3 transposed as their own
+ * block -- 01 02 03 04 05 09 0D 06 0A 0E 07 0B 0F 08 0C 10 -- which is what
+ * this test pins against. */
+static int test_bss_exact_page_bytes(void) {
+    const char* name = "bss_exact_page_bytes";
+    char path[512]; carquet_test_temp_path(path, sizeof(path), "ext_bss_bytes");
+    carquet_error_t err = CARQUET_ERROR_INIT;
+
+    static const int32_t in[4] = {
+        0x04030201, 0x08070605, 0x0C0B0A09, 0x100F0E0D
+    };
+    static const uint8_t expect[16] = {
+        0x01, 0x05, 0x09, 0x0D,
+        0x02, 0x06, 0x0A, 0x0E,
+        0x03, 0x07, 0x0B, 0x0F,
+        0x04, 0x08, 0x0C, 0x10
+    };
+
+    carquet_schema_t* s = carquet_schema_create(&err);
+    if (!s) TEST_FAIL(name, "schema create");
+    if (carquet_schema_add_column(s, "v", CARQUET_PHYSICAL_INT32, NULL,
+            CARQUET_REPETITION_REQUIRED, 0, 0) != CARQUET_OK)
+        { carquet_schema_free(s); TEST_FAIL(name, "add col"); }
+
+    carquet_writer_options_t wo; carquet_writer_options_init(&wo);
+    wo.compression = CARQUET_COMPRESSION_UNCOMPRESSED;  /* payload is the values */
+    carquet_writer_t* w = carquet_writer_create(path, s, &wo, &err);
+    if (!w) { carquet_schema_free(s); TEST_FAIL(name, "writer create"); }
+    if (carquet_writer_set_column_encoding(w, 0,
+            CARQUET_ENCODING_BYTE_STREAM_SPLIT) != CARQUET_OK)
+        { carquet_writer_close(w); carquet_schema_free(s);
+          TEST_FAIL(name, "set encoding"); }
+    /* Split across two calls: one page, two batches. */
+    if (carquet_writer_write_batch(w, 0, in, 1, NULL, NULL) != CARQUET_OK ||
+        carquet_writer_write_batch(w, 0, in + 1, 3, NULL, NULL) != CARQUET_OK)
+        { carquet_writer_close(w); carquet_schema_free(s);
+          TEST_FAIL(name, "write batch"); }
+    if (carquet_writer_close(w) != CARQUET_OK)
+        { carquet_schema_free(s); TEST_FAIL(name, "close"); }
+    carquet_schema_free(s);
+
+    carquet_reader_t* r = carquet_reader_open(path, NULL, &err);
+    if (!r) { carquet_test_cleanup(path); TEST_FAIL(name, "open"); }
+    carquet_column_chunk_metadata_t cm;
+    if (carquet_reader_column_chunk_metadata(r, 0, 0, &cm) != CARQUET_OK)
+        { carquet_reader_close(r); carquet_test_cleanup(path);
+          TEST_FAIL(name, "chunk meta"); }
+
+    uint8_t* fb = NULL; size_t fsz = 0;
+    if (!read_file(path, &fb, &fsz))
+        { carquet_reader_close(r); carquet_test_cleanup(path);
+          TEST_FAIL(name, "read file"); }
+
+    parquet_page_header_t ph; size_t consumed = 0;
+    carquet_status_t pst = parquet_parse_page_header(
+        fb + cm.data_page_offset, fsz - (size_t)cm.data_page_offset,
+        &ph, &consumed, &err);
+    int ok = (pst == CARQUET_OK) &&
+             (ph.uncompressed_page_size == (int32_t)sizeof(expect));
+    if (ok) {
+        const uint8_t* payload = fb + cm.data_page_offset + consumed;
+        ok = (memcmp(payload, expect, sizeof(expect)) == 0);
+        if (!ok) {
+            fprintf(stderr, "  expected:");
+            for (size_t i = 0; i < sizeof(expect); i++) fprintf(stderr, " %02X", expect[i]);
+            fprintf(stderr, "\n  actual:  ");
+            for (size_t i = 0; i < sizeof(expect); i++) fprintf(stderr, " %02X", payload[i]);
+            fprintf(stderr, "\n");
+        }
+    }
+    free(fb);
+    carquet_reader_close(r); carquet_test_cleanup(path);
+    if (!ok) TEST_FAIL(name, "page payload is not the expected byte planes");
+    TEST_PASS(name);
+    return 0;
+}
+
 int main(void) {
     int failures = 0;
     failures += test_int96_roundtrip();
+    failures += test_bss_exact_page_bytes();
     failures += test_data_page_v2(0);
     failures += test_data_page_v2(1);
     failures += test_arrow_schema_metadata();


### PR DESCRIPTION
Fixes #24.

BYTE_STREAM_SPLIT rearranges a whole page into byte planes, so it can only be
applied to the finished page. Every encoder path applied it to the current
call's subrange and appended the result, so a page assembled from several
`carquet_writer_write_batch()` calls became several independently transposed
regions that the reader de-splits as one stride. Every value after the first
batch came back wrong, silently.

All five physical types the encoding supports are affected: `FLOAT`, `DOUBLE`,
`INT32`, `INT64`, `FIXED_LEN_BYTE_ARRAY`. `FLOAT`/`DOUBLE` need no opt-in --
`effective_column_encoding()` selects BYTE_STREAM_SPLIT for them whenever a
codec is set.

## Change

Raw values accumulate in `values_buffer`; `apply_byte_stream_split()` transposes
the page once from `carquet_page_writer_finalize_to_buffer()`. The element width
comes from the physical type (`type_length` for FLBA) rather than from a
FLOAT-or-DOUBLE ternary, the transpose is byte-wise so it does not depend on
buffer alignment, and `bss_applied` makes it idempotent within a page since
finalize can run more than once before `carquet_page_writer_reset()`.

The three now-unused `extern` declarations for the incremental encoders are
dropped from `page_writer.c`; the functions themselves are untouched and still
used by `tests/`.

## Tests

`test_encoding_roundtrip.c` gains `bss_*_chunked` for all five types, writing
each page as 7 + 1 + 1992 + 2000 values so no boundary lands on a value-width
multiple. All five fail before this change.

The existing `bss_*` cases could not catch this: `write_then_open()` writes the
whole column in one call, the single case where per-call and per-page splitting
agree.

`test_writer_extensions.c` gains `bss_exact_page_bytes`, a byte-level assertion
per the contributing guide -- a round-trip through carquet's own decoder cannot
distinguish a correct page from a self-consistently wrong one. Four INT32 values
are chosen so their little-endian bytes are readable (`01 02 03 04`,
`05 06 07 08`, `09 0A 0B 0C`, `0D 0E 0F 10`), written as 1 + 3, and the
uncompressed page payload is asserted to be exactly

```
01 05 09 0D | 02 06 0A 0E | 03 07 0B 0F | 04 08 0C 10
```

hand-derived from the spec rather than computed by the code under test. On
`main` it is not that.

## Gate

- `ctest`: 39/39, Release and Debug.
- ASan + UBSan (`-fno-sanitize-recover=all`): 39/39, no errors, no leaks
  reported. LeakSanitizer is unavailable on macOS/arm64, so the leak half is
  from the UBSan/ASan run only, not from LSan.
- Fuzzing: all 12 targets, 60s each, sanitizers on, all clean
  (`python3 fuzz/run_fuzzer.py all --time 60`). That is a superset of the
  targets this change reaches -- `writer`, `roundtrip`, `append` and
  `nested_write` are the relevant ones.
- No new test files, so no `CMakeLists.txt` / `xmake.lua` wiring needed.
- Platform: Apple M1, macOS. Not built on MSVC or Linux locally.

## Note

Found while vendoring carquet into an R package. I am not changing the
BYTE_STREAM_SPLIT decoder or `carquet_byte_stream_split_encode*()`, only where
the transposition happens.
