### PR TITLE
writer: continue PLAIN BOOLEAN bit packing across write_batch calls

### DIFF
--- a/src/writer/page_writer.c
+++ b/src/writer/page_writer.c
@@ -143,6 +143,7 @@ typedef struct carquet_page_writer {
     int64_t* def_level_hist;
 
     bool data_page_v2;       /* Emit DATA_PAGE_V2 instead of DATA_PAGE */
+    int64_t bool_bits;       /* PLAIN BOOLEAN bits packed into this page */
 
     int32_t compression_level;   /* 0 = use codec default */
 
@@ -316,6 +317,7 @@ void carquet_page_writer_destroy(carquet_page_writer_t* writer) {
 
 void carquet_page_writer_reset(carquet_page_writer_t* writer) {
     carquet_buffer_clear(&writer->values_buffer);
+    writer->bool_bits = 0;
     carquet_buffer_clear(&writer->def_levels_buffer);
     carquet_buffer_clear(&writer->rep_levels_buffer);
     carquet_buffer_clear(&writer->staging_buffer);
@@ -907,6 +909,50 @@ static carquet_status_t encode_plain_double_with_stats(
 #endif
 }
 
+/* Append booleans to the page's PLAIN bit stream, continuing from the bit
+ * position the previous call left.
+ *
+ * Parquet packs a page's booleans as one continuous little-endian bit stream.
+ * carquet_encode_plain_boolean() always starts a fresh byte, so a column
+ * written in several batches restarted the stream at each call whose running
+ * count was not a multiple of 8, and every value after the first batch landed
+ * on the wrong bit. */
+static carquet_status_t append_plain_boolean(
+    carquet_page_writer_t* writer,
+    const uint8_t* values,
+    int64_t count) {
+
+    if (count == 0) {
+        return CARQUET_OK;
+    }
+
+    int64_t start_bit = writer->bool_bits;
+    size_t have_bytes = (size_t)((start_bit + 7) / 8);
+    size_t need_bytes = (size_t)((start_bit + count + 7) / 8);
+
+    if (need_bytes > have_bytes) {
+        uint8_t* grown = carquet_buffer_advance(&writer->values_buffer,
+                                                need_bytes - have_bytes);
+        if (!grown) {
+            return CARQUET_ERROR_OUT_OF_MEMORY;
+        }
+        /* Only the newly added bytes need clearing; the partial byte already
+         * in the buffer holds bits this call must preserve. */
+        memset(grown, 0, need_bytes - have_bytes);
+    }
+
+    uint8_t* base = writer->values_buffer.data +
+                    (writer->values_buffer.size - need_bytes);
+    for (int64_t i = 0; i < count; i++) {
+        if (values[i]) {
+            int64_t bit = start_bit + i;
+            base[bit >> 3] |= (uint8_t)(1u << (bit & 7));
+        }
+    }
+    writer->bool_bits = start_bit + count;
+    return CARQUET_OK;
+}
+
 static carquet_status_t encode_float_values(
     carquet_page_writer_t* writer,
     const float* values,
@@ -1195,8 +1241,7 @@ carquet_status_t carquet_page_writer_add_values(
                 }
                 carquet_buffer_destroy(&rle);
             } else {
-                status = carquet_encode_plain_boolean(bools, num_non_null,
-                                                       &writer->values_buffer);
+                status = append_plain_boolean(writer, bools, num_non_null);
             }
             if (status == CARQUET_OK && writer->write_statistics) {
                 update_statistics_boolean(writer, bools, num_non_null);

--- a/tests/test_writer_extensions.c
+++ b/tests/test_writer_extensions.c
@@ -1247,9 +1247,140 @@ static int test_file_format_version(void) {
     return 0;
 }
 
+/* ---- PLAIN BOOLEAN across several write_batch calls ---- */
+/* Parquet packs a page's booleans as one continuous bit stream, so a page
+ * written in several calls must produce the same bytes as one written in a
+ * single call. The chunk sizes below are deliberately not multiples of 8, so
+ * every batch after the first starts mid-byte. */
+static int test_boolean_chunked_writes(void) {
+    const char* name = "boolean_chunked_writes";
+    char path[512]; carquet_test_temp_path(path, sizeof(path), "ext_bool_chunk");
+    carquet_error_t err = CARQUET_ERROR_INIT;
+    static const int64_t chunks[] = { 5, 3, 991, 1, 4000 };
+
+    static uint8_t in[N], out[N];
+    for (int i = 0; i < N; i++) in[i] = (uint8_t)((i * 7 + (i / 3)) & 1);
+
+    carquet_schema_t* s = carquet_schema_create(&err);
+    if (!s) TEST_FAIL(name, "schema create");
+    if (carquet_schema_add_column(s, "b", CARQUET_PHYSICAL_BOOLEAN, NULL,
+            CARQUET_REPETITION_REQUIRED, 0, 0) != CARQUET_OK)
+        { carquet_schema_free(s); TEST_FAIL(name, "add col"); }
+
+    carquet_writer_options_t wo; carquet_writer_options_init(&wo);
+    carquet_writer_t* w = carquet_writer_create(path, s, &wo, &err);
+    if (!w) { carquet_schema_free(s); TEST_FAIL(name, "writer create"); }
+    int64_t done = 0;
+    for (size_t k = 0; k < sizeof(chunks) / sizeof(chunks[0]); k++) {
+        if (carquet_writer_write_batch(w, 0, in + done, chunks[k],
+                                       NULL, NULL) != CARQUET_OK)
+            { carquet_writer_close(w); carquet_schema_free(s);
+              TEST_FAIL(name, "write batch"); }
+        done += chunks[k];
+    }
+    if (carquet_writer_close(w) != CARQUET_OK)
+        { carquet_schema_free(s); TEST_FAIL(name, "close"); }
+    carquet_schema_free(s);
+
+    carquet_reader_t* r = carquet_reader_open(path, NULL, &err);
+    if (!r) { carquet_test_cleanup(path); TEST_FAIL(name, "open"); }
+    carquet_column_reader_t* c = carquet_reader_get_column(r, 0, 0, &err);
+    int64_t n = c ? carquet_column_read_batch(c, out, N, NULL, NULL) : -1;
+    int ok = (done == N) && (n == N);
+    int64_t wrong = 0;
+    for (int64_t i = 0; i < N && ok; i++) if (in[i] != out[i]) wrong++;
+    ok = ok && (wrong == 0);
+    carquet_column_reader_free(c); carquet_reader_close(r); carquet_test_cleanup(path);
+    if (!ok) TEST_FAIL(name, "value mismatch");
+    TEST_PASS(name);
+    return 0;
+}
+
+/* ---- PLAIN BOOLEAN: exact on-disk bytes ---- */
+/* A round-trip through carquet's own decoder cannot distinguish a correct page
+ * from a self-consistently wrong one, so this asserts the literal page payload.
+ *
+ * Twelve booleans, written as 5 + 7 so the second batch starts at bit 5 --
+ * mid-byte, which is the case that was broken:
+ *
+ *   index  0 1 2 3 4 | 5 6 7 8 9 10 11
+ *   value  1 0 1 1 0 | 0 1 0 1 1  0  1
+ *
+ * PLAIN packs them LSB-first into a continuous stream:
+ *
+ *   byte 0 = bits 0..7  = 1,0,1,1,0,0,1,0 -> 0x4D  (1 + 4 + 8 + 64)
+ *   byte 1 = bits 8..11 = 1,1,0,1         -> 0x0B  (1 + 2 + 8)
+ *
+ * so the payload is exactly 4D 0B. Restarting the stream at the second call
+ * instead emits the first 5 bits, pads to a byte, and starts again, giving
+ * 0D 5A -- which is what this pins against. */
+static int test_boolean_exact_page_bytes(void) {
+    const char* name = "boolean_exact_page_bytes";
+    char path[512]; carquet_test_temp_path(path, sizeof(path), "ext_bool_bytes");
+    carquet_error_t err = CARQUET_ERROR_INIT;
+
+    static const uint8_t in[12] = { 1,0,1,1,0, 0,1,0,1,1,0,1 };
+    static const uint8_t expect[2] = { 0x4D, 0x0B };
+
+    carquet_schema_t* s = carquet_schema_create(&err);
+    if (!s) TEST_FAIL(name, "schema create");
+    if (carquet_schema_add_column(s, "b", CARQUET_PHYSICAL_BOOLEAN, NULL,
+            CARQUET_REPETITION_REQUIRED, 0, 0) != CARQUET_OK)
+        { carquet_schema_free(s); TEST_FAIL(name, "add col"); }
+
+    carquet_writer_options_t wo; carquet_writer_options_init(&wo);
+    wo.compression = CARQUET_COMPRESSION_UNCOMPRESSED;  /* payload is the values */
+    carquet_writer_t* w = carquet_writer_create(path, s, &wo, &err);
+    if (!w) { carquet_schema_free(s); TEST_FAIL(name, "writer create"); }
+    if (carquet_writer_write_batch(w, 0, in, 5, NULL, NULL) != CARQUET_OK ||
+        carquet_writer_write_batch(w, 0, in + 5, 7, NULL, NULL) != CARQUET_OK)
+        { carquet_writer_close(w); carquet_schema_free(s);
+          TEST_FAIL(name, "write batch"); }
+    if (carquet_writer_close(w) != CARQUET_OK)
+        { carquet_schema_free(s); TEST_FAIL(name, "close"); }
+    carquet_schema_free(s);
+
+    carquet_reader_t* r = carquet_reader_open(path, NULL, &err);
+    if (!r) { carquet_test_cleanup(path); TEST_FAIL(name, "open"); }
+    carquet_column_chunk_metadata_t cm;
+    if (carquet_reader_column_chunk_metadata(r, 0, 0, &cm) != CARQUET_OK)
+        { carquet_reader_close(r); carquet_test_cleanup(path);
+          TEST_FAIL(name, "chunk meta"); }
+
+    uint8_t* fb = NULL; size_t fsz = 0;
+    if (!read_file(path, &fb, &fsz))
+        { carquet_reader_close(r); carquet_test_cleanup(path);
+          TEST_FAIL(name, "read file"); }
+
+    parquet_page_header_t ph; size_t consumed = 0;
+    carquet_status_t pst = parquet_parse_page_header(
+        fb + cm.data_page_offset, fsz - (size_t)cm.data_page_offset,
+        &ph, &consumed, &err);
+    int ok = (pst == CARQUET_OK) &&
+             (ph.uncompressed_page_size == (int32_t)sizeof(expect));
+    if (ok) {
+        const uint8_t* payload = fb + cm.data_page_offset + consumed;
+        ok = (memcmp(payload, expect, sizeof(expect)) == 0);
+        if (!ok) {
+            fprintf(stderr, "  expected: %02X %02X\n  actual:   %02X %02X\n",
+                    expect[0], expect[1], payload[0], payload[1]);
+        }
+    } else if (pst == CARQUET_OK) {
+        fprintf(stderr, "  payload is %d bytes, expected %d\n",
+                ph.uncompressed_page_size, (int)sizeof(expect));
+    }
+    free(fb);
+    carquet_reader_close(r); carquet_test_cleanup(path);
+    if (!ok) TEST_FAIL(name, "page payload is not the expected bit stream");
+    TEST_PASS(name);
+    return 0;
+}
+
 int main(void) {
     int failures = 0;
     failures += test_int96_roundtrip();
+    failures += test_boolean_chunked_writes();
+    failures += test_boolean_exact_page_bytes();
     failures += test_data_page_v2(0);
     failures += test_data_page_v2(1);
     failures += test_arrow_schema_metadata();


### PR DESCRIPTION
Fixes #25.

Parquet packs a data page's booleans as one continuous little-endian bit stream.
`carquet_encode_plain_boolean()` always starts on a fresh byte and
`carquet_page_writer_add_values()` calls it once per batch, so a `BOOLEAN`
column written in several `carquet_writer_write_batch()` calls restarted the
stream at every call whose running count was not a multiple of 8. Every value
after such a batch landed on the wrong bit.

Silent, like #24: the file is structurally valid and reads back without error,
just with wrong values. PLAIN is the default encoding for `BOOLEAN`, so this
needs no opt-in.

## Change

`append_plain_boolean()` replaces the call in the PLAIN branch of
`carquet_page_writer_add_values()` and continues from the page's bit position,
tracked in `bool_bits` and cleared by `carquet_page_writer_reset()`. Only bytes
newly appended to `values_buffer` are zeroed -- the trailing partial byte holds
bits an earlier call wrote.

`carquet_encode_plain_boolean()` is unchanged and still used where a whole
vector is encoded in one shot. The RLE branch is untouched.

## Tests

`test_writer_extensions.c` gains two cases.

`boolean_chunked_writes` writes 5000 booleans as 5 + 3 + 991 + 1 + 4000, so four
of the five batches start mid-byte, and compares the read-back values.

`boolean_exact_page_bytes` is the byte-level assertion the contributing guide
asks for, since a round-trip through carquet's own decoder cannot tell a correct
page from a self-consistently wrong one. Twelve booleans

```
index  0 1 2 3 4 | 5 6 7 8 9 10 11
value  1 0 1 1 0 | 0 1 0 1 1  0  1
```

written as 5 + 7. Packed LSB-first that is `byte 0 = 1+4+8+64 = 0x4D` and
`byte 1 = 1+2+8 = 0x0B`, so the uncompressed page payload must be exactly
`4D 0B`. On `main` it is `0D 5A` -- the first five bits, padded to a byte, then
a restarted stream. Both values are hand-derived from the spec, not produced by
the code under test.

Both fail before this change.

## Gate

- `ctest`: 39/39, Release and Debug.
- ASan + UBSan (`-fno-sanitize-recover=all`): 39/39, no errors, no leaks
  reported. LeakSanitizer is unavailable on macOS/arm64, so the leak half comes
  from the ASan/UBSan run only, not from LSan.
- Fuzzing: all 12 targets, 60s each, sanitizers on, all clean
  (`python3 fuzz/run_fuzzer.py all --time 60`). A superset of what this change
  reaches -- `writer`, `roundtrip`, `append` and `nested_write` are the
  relevant ones.
- No new test files, so no `CMakeLists.txt` / `xmake.lua` wiring needed.
- Platform: Apple M1, macOS. Not built on MSVC or Linux locally.

## Note

While writing the test I noticed the RLE branch immediately above appends a
fresh 4-byte-length-prefixed RLE block per `add_values` call, which looks like
the same shape of problem -- a page written in several calls would hold several
concatenated streams while the reader reads only the first length prefix. I have
not confirmed that with a test and it is not touched here; mentioned in #25 in
case it is worth a look.
